### PR TITLE
Changes / Fix

### DIFF
--- a/DS2406.cpp
+++ b/DS2406.cpp
@@ -1,19 +1,19 @@
 #include <DS2406.h>
 
-OneWireSwitch::OneWireSwitch(OneWire *b, uint8_t *addr) {
+DS2406::DS2406(OneWire *b, uint8_t *addr) {
     bus = b;
     for(int i = 0; i<8; i++) {
         address[i] = addr[i];
     }
 }
 
-bool OneWireSwitch::getSwitchState(int port) {
+bool DS2406::getSwitchState(int port) {
     uint8_t status[DS2406_STATE_BUF_LEN];
     readStatus(status);
     return (status[7] & port) == 0;
 }
 
-void OneWireSwitch::setSwitchState(bool pio_a, bool pio_b) {
+void DS2406::setSwitchState(bool pio_a, bool pio_b) {
     uint8_t state = (!pio_a << 5) | (!pio_b << 6) | 0xf;
     bus->reset();
     bus->select(address);
@@ -30,7 +30,7 @@ void OneWireSwitch::setSwitchState(bool pio_a, bool pio_b) {
     bus->write(0xFF,1);
 }
 
-void OneWireSwitch::readStatus(uint8_t *buffer) {
+void DS2406::readStatus(uint8_t *buffer) {
     bus->reset();
     bus->select(address);
     bus->write(DS2406_READ_STATUS, 1);

--- a/DS2406.h
+++ b/DS2406.h
@@ -1,3 +1,6 @@
+#ifndef DS2406_h
+#define DS2406_h
+
 #include <OneWire.h>
 
 #include <inttypes.h>
@@ -12,14 +15,15 @@
 
 #define DS2406_STATE_BUF_LEN 10
 
+
 // Represents a single 1wire switch on an MLan.
-class OneWireSwitch {
+class DS2406 {
 
  public:
 
     // Construct the OneWireSwitch with the given OneWire bus and address.
     // addr must be 8 bytes.
-    OneWireSwitch(OneWire *b, uint8_t *addr);
+	DS2406(OneWire *b, uint8_t *addr);
 
     // Get the switch state.
     // An optional argument indicates *which* switch state in the case
@@ -35,3 +39,5 @@ class OneWireSwitch {
 
     void readStatus(uint8_t *buffer);
 };
+
+#endif

--- a/examples/Hello/Hello.pde
+++ b/examples/Hello/Hello.pde
@@ -4,7 +4,7 @@
 #include <DS2406.h>
 
 OneWire ow(7);
-OneWireSwitch osw(&ow,
+DS2406 osw(&ow,
                   // Specify the serial number of your DS2406 here.
                   (uint8_t[]){0x12, 0xE, 0xF9, 0x16, 0, 0, 0, 0xF6});
 

--- a/examples/SearchAndBlink/SearchAndBlink.pde
+++ b/examples/SearchAndBlink/SearchAndBlink.pde
@@ -48,7 +48,7 @@ void flipSwitch(uint8_t *addr) {
     // discovering them dynamically.  Depending on your app, you may
     // already know the serial number of the device you intend to
     // control and will use it there.
-    OneWireSwitch osw(&ow, addr);
+	DS2406 osw(&ow, addr);
 
     // Turn on the switch.
     osw.setSwitchState(true);


### PR DESCRIPTION
Hi,

i fixed a possible compilation problem by adding 
> #ifndef DS2406_h
> #define DS2406_h

I renamed the class to DS2406 because there are other Chips like DS2408 which can be a OneWireSwitch and the DS2406 can also be a Sensor.

Greetings
Dennis

